### PR TITLE
Issue/42 fix hirise idxlbl

### DIFF
--- a/bin/pdsc_util
+++ b/bin/pdsc_util
@@ -7,6 +7,7 @@ import pdsc
 
 SUBCOMMANDS = {
     'fix_hirise_index': pdsc.fix_hirise_index,
+    'fix_hirise_idxlbl': pdsc.fix_hirise_idxlbl
 }
 
 def main(*args, **kwargs):
@@ -32,6 +33,13 @@ if __name__ == '__main__':
         help='optional output file location (overwrite index if not specified)')
     hirise_fix_parser.add_argument('-q', '--quiet', default=False, action='store_true',
         help='do not display a progress bar')
+
+    hirise_idxlbl_parser = subparsers.add_parser('fix_hirise_idxlbl')
+    hirise_idxlbl_parser.add_argument('idx', help='cumulative index file location')
+    hirise_idxlbl_parser.add_argument('-o', '--outputfile', default=None,
+        help='optional output file location (overwrite index if not specified)')
+    hirise_idxlbl_parser.add_argument('-q', '--quiet', default=False,
+        action='store_true', help='do not print messages')
 
     args = parser.parse_args()
     main(**vars(args))

--- a/docs/Utilities.rst
+++ b/docs/Utilities.rst
@@ -2,8 +2,8 @@ Command Line Utilities
 ======================
 
 PDSC provides some command line utilties to provide useful functionality.
-Currently, only one utility is implemented to fix HiRISE EDR cumulative index
-files prior to ingesting them.
+Currently, two utilities are implemented to fix HiRISE EDR abd RDR cumulative
+index files prior to ingesting them.
 
 Fixing HiRISE EDR Indices
 -------------------------

--- a/docs/Utilities.rst
+++ b/docs/Utilities.rst
@@ -19,3 +19,19 @@ the following command::
 By default, the index file will be overwritten with a corrected version. A
 separate output file can also be specified (use the ``-h`` flag for a full set
 of options).
+
+Fixing HiRISE RDR Indices
+-------------------------
+
+There are some inconsistencies between the HiRISE RDR cumulative index file
+(.TAB) and its metadata file (.LBL). The number of lines in the cumulative
+index file doesn't match the entries of ``FILE_RECORDS`` and ``ROWS`` in the
+metadata file. The values of ``FILE_RECORDS`` and ```ROWS` should be modified
+with respect to the actual number of lines in the cumulative index file. This
+can be accomplished using the following command::
+
+    $ pdsc_util fix_hirise_idxlbl RDRCUMINDEX.TAB
+
+By default, the index file will be overwritten with a corrected version. A
+separate output file can also be specified using the ``-o`` flag provided.
+Please use ``-h`` flag for a full set of options.

--- a/docs/Utilities.rst
+++ b/docs/Utilities.rst
@@ -26,7 +26,7 @@ Fixing HiRISE RDR Indices
 There are some inconsistencies between the HiRISE RDR cumulative index file
 (.TAB) and its metadata file (.LBL). The number of lines in the cumulative
 index file doesn't match the entries of ``FILE_RECORDS`` and ``ROWS`` in the
-metadata file. The values of ``FILE_RECORDS`` and ```ROWS` should be modified
+metadata file. The values of ``FILE_RECORDS`` and ``ROWS`` should be modified
 with respect to the actual number of lines in the cumulative index file. This
 can be accomplished using the following command::
 

--- a/pdsc/version.py
+++ b/pdsc/version.py
@@ -1,2 +1,2 @@
-__version__     = '1.4.1'
+__version__     = '1.4.2'
 __description__ = 'Planetary Data System Coincidences'


### PR DESCRIPTION
@garydoranjr This pull request is related to issue #42. I added a tool (`fix_hirise_idxlbl`) in `pdsc_util` with the exact same command line interface as `fix_hirise_index`, and a unit test to verify the correctness of `fix_hirise_idxlbl`. The Utility doc was also updated to include the usage instructions for `fix_hirise_idxlbl`. In addition, I also manually tested `pdsc_ingest` tool to make sure the LBL file corrected by `fix_hirise_idxlbl` can still be ingested. 

Could you please take a look at the changes I made and let me know if there is anything I should change? If the changes look good, could you please approve and merge these changes into the master branch? Thanks!